### PR TITLE
"Constructible from" skill

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ include(cmake/prelude.cmake)
 
 project(
   stronk
-  VERSION 0.2.0
+  VERSION 0.3.0
   DESCRIPTION "An easy to customize strong type library with built in support for unit-like behavior"
   HOMEPAGE_URL "https://github.com/twig-energy/stronk"
   LANGUAGES NONE

--- a/README.md
+++ b/README.md
@@ -162,6 +162,7 @@ Skills adds functionality to your stronk types. We have implemented a number of 
 - `can_iterate` adds the `can_const_iterate` as well implementing `begin()`, `end()`.
 - `can_const_index` implements `operator[](const auto&) const` and `at(const auto&) const`
 - `can_index` adds the `can_const_index` as well implementing `operator[](const auto&)` and `at(const auto&)`.
+- `can_forward_constructor_args` adds a constructor which forwards arguments to the inner class.
 
 ### Units
 - `unit`: enables unit behavior for multiplication and division.

--- a/include/stronk/prefabs.h
+++ b/include/stronk/prefabs.h
@@ -15,7 +15,7 @@ struct stronk_default_unit
              can_negate,
              can_order,
              default_can_equate_builder<T>::template skill,
-             can_forward_constructor_arg,
+             can_forward_constructor_args,
              Skills...>
 {
     using stronk<Tag,
@@ -26,7 +26,7 @@ struct stronk_default_unit
                  can_negate,
                  can_order,
                  default_can_equate_builder<T>::template skill,
-                 can_forward_constructor_arg,
+                 can_forward_constructor_args,
                  Skills...>::stronk;
 };
 

--- a/include/stronk/prefabs.h
+++ b/include/stronk/prefabs.h
@@ -15,6 +15,7 @@ struct stronk_default_unit
              can_negate,
              can_order,
              default_can_equate_builder<T>::template skill,
+             can_forward_constructor_arg,
              Skills...>
 {
     using stronk<Tag,
@@ -25,6 +26,7 @@ struct stronk_default_unit
                  can_negate,
                  can_order,
                  default_can_equate_builder<T>::template skill,
+                 can_forward_constructor_arg,
                  Skills...>::stronk;
 };
 

--- a/include/stronk/unit.h
+++ b/include/stronk/unit.h
@@ -90,6 +90,7 @@ struct NewUnitType
              can_subtract,
              can_negate,
              default_can_equate_builder<T>::template skill,
+             can_forward_constructor_arg,
              unit_type_list_skill_builder<UnitTypeListsT>::template skill>
 {
     using stronk<NewUnitType<T, UnitTypeListsT>,
@@ -99,6 +100,7 @@ struct NewUnitType
                  can_subtract,
                  can_negate,
                  default_can_equate_builder<T>::template skill,
+                 can_forward_constructor_arg,
                  unit_type_list_skill_builder<UnitTypeListsT>::template skill>::stronk;
 };
 

--- a/include/stronk/unit.h
+++ b/include/stronk/unit.h
@@ -90,7 +90,7 @@ struct NewUnitType
              can_subtract,
              can_negate,
              default_can_equate_builder<T>::template skill,
-             can_forward_constructor_arg,
+             can_forward_constructor_args,
              unit_type_list_skill_builder<UnitTypeListsT>::template skill>
 {
     using stronk<NewUnitType<T, UnitTypeListsT>,
@@ -100,7 +100,7 @@ struct NewUnitType
                  can_subtract,
                  can_negate,
                  default_can_equate_builder<T>::template skill,
-                 can_forward_constructor_arg,
+                 can_forward_constructor_args,
                  unit_type_list_skill_builder<UnitTypeListsT>::template skill>::stronk;
 };
 

--- a/tests/src/stronk_tests.cpp
+++ b/tests/src/stronk_tests.cpp
@@ -607,12 +607,18 @@ struct a_type_with_a_constructor
 };
 
 struct a_convert_constructible_type
-    : stronk<a_convert_constructible_type, a_type_with_a_constructor, can_forward_constructor_arg>
+    : stronk<a_convert_constructible_type, a_type_with_a_constructor, can_forward_constructor_args>
+{
+    using stronk::stronk;
+};
+
+struct a_none_convert_constructible_type : stronk<a_none_convert_constructible_type, a_type_with_a_constructor>
 {
     using stronk::stronk;
 };
 
 static_assert(std::constructible_from<a_type_with_a_constructor, int>);
+static_assert(!std::constructible_from<a_none_convert_constructible_type, int>);
 
 TEST(convert_constructible, its_possible_to_construct_inner_value_via_convertible_value)  // NOLINT
 {

--- a/tests/src/stronk_tests.cpp
+++ b/tests/src/stronk_tests.cpp
@@ -536,10 +536,14 @@ TEST(can_index, can_index_works_for_vectors)  // NOLINT
 template<an_int_test_type Val>
 struct type_which_requires_stronk_none_type_template_param
 {
+    static constexpr an_int_test_type value = Val;
 };
 
-constexpr static auto instantiation_of_a_stronk_non_type_template_param =
-    type_which_requires_stronk_none_type_template_param<an_int_test_type {25}>();
+TEST(none_type_template_parameter, stronk_types_can_be_used_as_none_type_template_parameters)  // NOLINT
+{
+    auto val = type_which_requires_stronk_none_type_template_param<an_int_test_type {25}> {};
+    EXPECT_EQ(val.value.unwrap<an_int_test_type>(), 25);
+}
 
 struct MarkIfMovedType
 {
@@ -591,4 +595,29 @@ TEST(move, stronk_allows_to_move_and_move_out_with_unwrap)  // NOLINT
         EXPECT_TRUE(marker);
     }
 }
+
+struct a_type_with_a_constructor
+{
+    int val;
+
+    explicit a_type_with_a_constructor(int val)
+        : val(val)
+    {
+    }
+};
+
+struct a_convert_constructible_type
+    : stronk<a_convert_constructible_type, a_type_with_a_constructor, can_forward_constructor_arg>
+{
+    using stronk::stronk;
+};
+
+static_assert(std::constructible_from<a_type_with_a_constructor, int>);
+
+TEST(convert_constructible, its_possible_to_construct_inner_value_via_convertible_value)  // NOLINT
+{
+    auto val = a_convert_constructible_type(42);  // NOLINT
+    EXPECT_EQ(val.unwrap<a_convert_constructible_type>().val, 42);
+}
+
 }  // namespace twig

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -2,7 +2,7 @@
   "name": "stronk",
   "homepage": "https://github.com/twig-energy/stronk",
   "description": "An easy to customize, strong type library with built in support for unit-like behavior",
-  "version-semver": "0.2.0",
+  "version-semver": "0.3.0",
   "license": "MIT",
   "dependencies": [
     {


### PR DESCRIPTION
- Added a skill for forwarding a constructor argument
- Default units to be constructible from
- Made the forward constructor argument variadic
- Bumped version to 0.3.0
