### PR TITLE
Measure the vectorized loop in the SIMD benchmarks

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ include(cmake/prelude.cmake)
 
 project(
     stronk
-    VERSION 0.16.3
+    VERSION 0.16.4
     DESCRIPTION "An easy to customize strong type library with built in support for unit-like behavior"
     HOMEPAGE_URL "https://github.com/twig-energy/stronk"
     LANGUAGES CXX

--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -29,6 +29,8 @@ target_compile_features(stronk_benchmarks PRIVATE cxx_std_20)
 target_compile_options(
     stronk_benchmarks PRIVATE $<$<OR:$<CXX_COMPILER_ID:GNU>,$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>>: -Wno-conversion -Wno-c2y-extensions>
 )
+# Sub-nanosecond loops, so the rows shift with loop placement unless padded.
+target_compile_options(stronk_benchmarks PRIVATE $<$<CXX_COMPILER_ID:GNU>:-falign-loops=32>)
 
 # ---- End-of-file commands ----
 add_folders(Benchmarks)

--- a/benchmarks/src/unit_benchmarks.cpp
+++ b/benchmarks/src/unit_benchmarks.cpp
@@ -57,6 +57,17 @@ struct divide
     }
 };
 
+// The barrier copies a class-type operand to the stack, so it gets the scalar instead.
+template<typename T>
+constexpr auto underlying_of(T& value) -> auto&
+{
+    if constexpr (twig::stronk_like<T>) {
+        return value.template unwrap<T>();
+    } else {
+        return value;
+    }
+}
+
 template<typename T, typename O, typename Op>
 void benchmark_units_operation(ankerl::nanobench::Bench& bench, size_t size, const Op& op, O o_min_val = O {})
 {
@@ -99,7 +110,7 @@ void benchmark_units_simd_operation(ankerl::nanobench::Bench& bench, size_t size
                                       array_c[j] = op(vec_a[i + j], vec_b[i + j]);  // NOLINT
                                   }
                                   for (size_t j = 0; j < WidthV; j++) {
-                                      ankerl::nanobench::doNotOptimizeAway(array_c[j]);  // NOLINT
+                                      ankerl::nanobench::doNotOptimizeAway(underlying_of(array_c[j]));  // NOLINT
                                   }
                               }
                           });

--- a/benchmarks/src/unit_benchmarks.cpp
+++ b/benchmarks/src/unit_benchmarks.cpp
@@ -57,17 +57,6 @@ struct divide
     }
 };
 
-// The barrier copies a class-type operand to the stack, so it gets the scalar instead.
-template<typename T>
-constexpr auto underlying_of(T& value) -> auto&
-{
-    if constexpr (twig::stronk_like<T>) {
-        return value.template unwrap<T>();
-    } else {
-        return value;
-    }
-}
-
 template<typename T, typename O, typename Op>
 void benchmark_units_operation(ankerl::nanobench::Bench& bench, size_t size, const Op& op, O o_min_val = O {})
 {
@@ -101,19 +90,25 @@ void benchmark_units_simd_operation(ankerl::nanobench::Bench& bench, size_t size
         size -= size % WidthV;  // Ensure size is a multiple of WidthV
     }
 
-    bench.batch(size).run(fmt::format("{} {} {}", get_name<T>(), Op::name, get_name<O>()),
-                          [&vec_a, &vec_b, &op, &array_c]() -> void
-                          {
-                              for (auto i = 0ULL; i < vec_a.size(); i += WidthV) {
-                                  // We expect the inner loop to be vectorized to SIMD instructions
-                                  for (size_t j = 0; j < WidthV; j++) {
-                                      array_c[j] = op(vec_a[i + j], vec_b[i + j]);  // NOLINT
-                                  }
-                                  for (size_t j = 0; j < WidthV; j++) {
-                                      ankerl::nanobench::doNotOptimizeAway(underlying_of(array_c[j]));  // NOLINT
-                                  }
-                              }
-                          });
+    bench.batch(size).run(
+        fmt::format("{} {} {}", get_name<T>(), Op::name, get_name<O>()),
+        [&vec_a, &vec_b, &op, &array_c]() -> void
+        {
+            for (auto i = 0ULL; i < vec_a.size(); i += WidthV) {
+                // We expect the inner loop to be vectorized to SIMD instructions
+                for (size_t j = 0; j < WidthV; j++) {
+                    array_c[j] = op(vec_a[i + j], vec_b[i + j]);  // NOLINT
+                }
+                for (size_t j = 0; j < WidthV; j++) {
+                    // the barrier copies a class-type operand to the stack, so it gets the scalar
+                    if constexpr (twig::stronk_like<ResT>) {
+                        ankerl::nanobench::doNotOptimizeAway(array_c[j].template unwrap<ResT>());  // NOLINT
+                    } else {
+                        ankerl::nanobench::doNotOptimizeAway(array_c[j]);  // NOLINT
+                    }
+                }
+            }
+        });
 }
 
 template<typename T>

--- a/benchmarks/src/unit_benchmarks.cpp
+++ b/benchmarks/src/unit_benchmarks.cpp
@@ -9,6 +9,7 @@
 #include <nanobench.h>
 
 #include "./benchmark_helpers.hpp"
+#include "stronk/stronk.hpp"
 
 namespace
 {

--- a/benchmarks/src/unit_benchmarks.cpp
+++ b/benchmarks/src/unit_benchmarks.cpp
@@ -73,12 +73,12 @@ void benchmark_units_operation(ankerl::nanobench::Bench& bench, size_t size, con
 {
     auto vec_a = std::vector<T>(size);
     auto vec_b = std::vector<O>(size);
-    std::ranges::generate(vec_a, []() { return generate_randomish<T> {}(); });
-    std::ranges::generate(vec_b, [&o_min_val]() { return generate_randomish<O> {}() + o_min_val; });
+    std::ranges::generate(vec_a, []() -> T { return generate_randomish<T> {}(); });
+    std::ranges::generate(vec_b, [&o_min_val]() -> O { return generate_randomish<O> {}() + o_min_val; });
 
     auto tmp = decltype(op(T {}, O {})) {};
     bench.batch(size).run(fmt::format("{} {} {}", get_name<T>(), Op::name, get_name<O>()),
-                          [&vec_a, &vec_b, &op, &tmp]()
+                          [&vec_a, &vec_b, &op, &tmp]() -> void
                           {
                               for (auto i = 0ULL; i < vec_a.size(); i++) {
                                   tmp = op(vec_a[i], vec_b[i]);  // NOLINT
@@ -92,8 +92,8 @@ void benchmark_units_simd_operation(ankerl::nanobench::Bench& bench, size_t size
 {
     auto vec_a = std::vector<T>(size);
     auto vec_b = std::vector<O>(size);
-    std::ranges::generate(vec_a, []() { return generate_randomish<T> {}(); });
-    std::ranges::generate(vec_b, [&o_min_val]() { return generate_randomish<O> {}() + o_min_val; });
+    std::ranges::generate(vec_a, []() -> T { return generate_randomish<T> {}(); });
+    std::ranges::generate(vec_b, [&o_min_val]() -> O { return generate_randomish<O> {}() + o_min_val; });
 
     using ResT = decltype(op(T {}, O {}));
     auto array_c = std::array<ResT, WidthV> {};
@@ -102,7 +102,7 @@ void benchmark_units_simd_operation(ankerl::nanobench::Bench& bench, size_t size
     }
 
     bench.batch(size).run(fmt::format("{} {} {}", get_name<T>(), Op::name, get_name<O>()),
-                          [&vec_a, &vec_b, &op, &array_c]()
+                          [&vec_a, &vec_b, &op, &array_c]() -> void
                           {
                               for (auto i = 0ULL; i < vec_a.size(); i += WidthV) {
                                   // We expect the inner loop to be vectorized to SIMD instructions


### PR DESCRIPTION
### Why
The SIMD benchmark rows for stronk read 60% to 70% of the primitive on gcc (#67).

With gcc, the vectorized math loop compiles to the same instructions for `double` and `stronk_double_t`. The difference is in the `ankerl::nanobench::doNotOptimizeAway` loop: the call makes gcc emit a copy to the stack before it for a struct operand, which it does not for a `double`.

I did not find out why gcc does this, but a plain `struct { double v; }` gets the same copy, so it does not look stronk specific. Passing the underlying scalar to `doNotOptimizeAway` avoids the copy while appearing still keeping the math alive.

But some metrics still read 60% to 70% with the change, and they tend to be different each build. LLM suggested adding only `-falign-loops=32` took it to ~100%. <- this is supposed to fix the alignment of generated code, but I am not entirely sure why this fixed it. might be more detailed behavior on cpu instructions that I have very limited knowledge of.

Clang is unchanged and looks like a different problem, see #67.

### What was changed
- apply the barrier to the underlying scalar in `benchmark_units_simd_operation`
- `-falign-loops=32` on the benchmark target for gcc
- version 0.16.4